### PR TITLE
Make view opaque by default

### DIFF
--- a/Sources/TextureView/TextureView.swift
+++ b/Sources/TextureView/TextureView.swift
@@ -111,7 +111,6 @@ public class TextureView: UIView {
     private func commonInit() {
         self.layer.device = self.device
         self.layer.framebufferOnly = true
-        self.layer.isOpaque = false
         self.layer.maximumDrawableCount = 3
         
         self.renderPassDescriptor.colorAttachments[0].loadAction = .clear


### PR DESCRIPTION
Opaque views are preferred by default for performance reasons. 
Users are still able to make it transparent via `textureView.isOpaque` or `textureView.layer.isOpaque`. 